### PR TITLE
Btn reutilizable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,53 +2,25 @@ module.exports = {
   env: {
     browser: true,
     es2021: true,
-    node: true,
+    node: true
   },
   extends: [
     'plugin:react/recommended',
-    'airbnb',
     'plugin:@typescript-eslint/recommended',
-    'prettier',
+    'prettier'
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {
-      jsx: true,
+      jsx: true
     },
-    ecmaVersion: 12,
-    sourceType: 'module',
+    ecmaVersion: 'latest',
+    sourceType: 'module'
   },
   plugins: ['react', '@typescript-eslint'],
   rules: {
-    // Permite console.log, pero muestra una advertencia en la consola
     'no-console': 'warn',
-    // Permite el uso de dependencias de desarrollo en los archivos de prueba y configuración
-    'import/no-extraneous-dependencies': [
-      'error',
-      { devDependencies: ['**/test.tsx', '**/test.ts', '**/*.config.js'] },
-    ],
-    // Permite la reasignación de propiedades de objetos (útil para trabajar con reducers)
-    'no-param-reassign': ['error', { props: false }],
-    // No requiere que las extensiones .tsx y .ts se especifiquen al importar
-    'import/extensions': [
-      'error',
-      'ignorePackages',
-      {
-        js: 'never',
-        jsx: 'never',
-        ts: 'never',
-        tsx: 'never',
-      },
-    ],
-    // No requiere declaraciones de tipo de propiedades con TypeScript
-    'react/prop-types': 'off',
-    // No requiere el uso de 'this' en los métodos de clase que no lo utilizan
-    'class-methods-use-this': 'off',
-    // No aplicar una máxima longitud de línea, dejando que Prettier se encargue del formateo
-    'max-len': 'off',
-    // Permitir ciertos métodos no modificadores en los arrays como .push
-    'no-array-constructor': 'off',
-    // No forzar el uso de desestructuración en objetos y arrays
-    'prefer-destructuring': 'off',
-  },
+    'no-unused-vars': 'warn',
+    'react/react-in-jsx-scope': 'off'
+  }
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,9 @@
 {
   "semi": true,
-  "trailingComma": "es5",
   "singleQuote": true,
   "printWidth": 80,
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "trailingComma": "none",
+  "jsxBracketSameLine": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "prettier": "^3.2.5"
+        "prettier": "^3.2.5",
+        "sass": "^1.71.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9328,6 +9329,12 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
+      "devOptional": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -15523,6 +15530,23 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-13.0.0.tgz",
       "integrity": "sha512-ZRwKbh/eQ6w9vmTjkuG0Ioi3HBwPFce0O+v//ve+aOq1oeCy7jMV2qzzAlpsNuqpqCBjjriM1lbtZbF/Q8jVyA=="
+    },
+    "node_modules/sass": {
+      "version": "1.71.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.1.tgz",
+      "integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
+      "devOptional": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/sass-loader": {
       "version": "12.6.0",

--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
     ]
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.18.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "prettier": "^3.2.5",
-    "@babel/plugin-proposal-private-property-in-object": "^7.18.0"
+    "sass": "^1.71.1"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders realizar prueba button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const buttonElement = screen.getByText(/Realizar Prueba/i);
+  expect(buttonElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,16 @@
+import React from 'react';
+import { Button } from './components/common/Button';
+
 const App = () => {
   return (
     <div className="App">
-      <h1>Hola MUNDO!!!</h1>
+      <Button
+        onClick={function (): void {
+          throw new Error('Function not implemented.');
+        }}
+      >
+        Realizar Prueba
+      </Button>
     </div>
   );
 };

--- a/src/components/common/Button/Button.module.scss
+++ b/src/components/common/Button/Button.module.scss
@@ -1,0 +1,12 @@
+.button {
+  padding: 10px 15px;
+  border-radius: 5px;
+  cursor: pointer;
+  border: none;
+  background-color: #4caf50;
+  color: white;
+
+  &:hover {
+    background-color: #45a049;
+  }
+}

--- a/src/components/common/Button/Button.test.tsx
+++ b/src/components/common/Button/Button.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Button from './Button';
+
+describe('Button Component', () => {
+  test('renders button and responds to click event', () => {
+    const mockOnClick = jest.fn();
+    render(<Button onClick={mockOnClick}>Realizar prueba</Button>);
+    const buttonElement = screen.getByText(/realizar prueba/i);
+    fireEvent.click(buttonElement);
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,0 +1,38 @@
+import React, { FC } from 'react';
+import styles from './Button.module.scss';
+
+type ButtonProps = {
+  children: React.ReactNode;
+  onClick: () => void;
+  className?: string;
+  inlineStyle?: React.CSSProperties;
+};
+
+const Button: FC<ButtonProps> = ({
+  children,
+  onClick,
+  className,
+  inlineStyle
+}) => {
+  const combinedStyle = {
+    ...styles,
+    ...inlineStyle
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      className={className || styles.button}
+      style={combinedStyle}
+    >
+      {children}
+    </button>
+  );
+};
+
+Button.defaultProps = {
+  className: '',
+  inlineStyle: {}
+};
+
+export default Button;

--- a/src/components/common/Button/index.ts
+++ b/src/components/common/Button/index.ts
@@ -1,0 +1,1 @@
+export { default as Button } from './Button';

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,1 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';


### PR DESCRIPTION
**Ticket:** Historia de usuario 1, subtask 2.

**Imagenes apróxiamada de lo esperado:**

<img width="588" alt="image" src="https://github.com/Miyagito/prueba_test_react_app/assets/32531289/a1b0dd37-796c-4627-8661-47f513074be8">

<img width="350" alt="image" src="https://github.com/Miyagito/prueba_test_react_app/assets/32531289/85eceaee-55c0-47f9-8833-c486c02c711d">


**Descripción:** Button altamente reutilizable y flexible en términos de estilos. Al permitir que se pase un estilo personalizado a través de la prop inlineStyle, los usuarios del componente pueden sobrescribir fácilmente los estilos predeterminados con sus propios estilos personalizados.

Refactor en archivos de configuración para mantener fuera de conflictos Eslint y Prettier

**Tests**: Realizados con éxito

**Imagenes del desarrollo**: 

<img width="375" alt="image" src="https://github.com/Miyagito/prueba_test_react_app/assets/32531289/d8651987-2063-4b01-9d99-4554f1eb1558">

<img width="270" alt="image" src="https://github.com/Miyagito/prueba_test_react_app/assets/32531289/167e016b-8bd7-479c-b1a1-c3d85e56e577">
